### PR TITLE
Support new handle value

### DIFF
--- a/lywsd02/client.py
+++ b/lywsd02/client.py
@@ -119,6 +119,8 @@ class Lywsd02Client:
             self._process_sensor_data(data)
         if handle == 0x37:
             self._process_history_data(data)
+        if handle == 0x4b:
+            self._process_sensor_data(data)
 
     def _subscribe(self, uuid):
         self._peripheral.setDelegate(self)


### PR DESCRIPTION
This module not works on 1.2.2_0042.

Firmware 1.2.2_0042 notifies with `0x4b`

Thanks.