### PR TITLE
Use old style string replace for compatibility

### DIFF
--- a/lywsd02/client.py
+++ b/lywsd02/client.py
@@ -68,7 +68,7 @@ class Lywsd02Client:
     @with_connect
     def units(self, value):
         if value.upper() not in self.UNITS_CODES.keys():
-            raise ValueError(f'Units value must be one of {self.UNITS_CODES.keys()}')
+            raise ValueError('Units value must be one of %s' % self.UNITS_CODES.keys())
 
         ch = self._peripheral.getCharacteristics(uuid=UUID_UNITS)[0]
         ch.write(self.UNITS_CODES[value.upper()], withResponse=True)


### PR DESCRIPTION
Fixes #4.

- Use old style string replacement because f-strings were introduced in [Python 3.6](https://docs.python.org/3/reference/lexical_analysis.html#f-strings).