### PR TITLE
Decoding of Historic Data

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -66,6 +66,7 @@ with client.connect():
 * `client.units` – Current temperature units displayed on screen. Returns `'C'` for Celsius and `'F'` for Fahrenheit
 * `client.time` – Current time and timezone offset. Returns as tuple of `datetime.datetime` and `int`
 * `client.battery` – Sensor's battery level in percent (0 to 100).
+* `client.historic_data` – Ordered Dictionary of hourly averages with timestamp for minimum and maximum temperature and humidity
 
 ## Available setters
 

--- a/Readme.md
+++ b/Readme.md
@@ -66,7 +66,7 @@ with client.connect():
 * `client.units` – Current temperature units displayed on screen. Returns `'C'` for Celsius and `'F'` for Fahrenheit
 * `client.time` – Current time and timezone offset. Returns as tuple of `datetime.datetime` and `int`
 * `client.battery` – Sensor's battery level in percent (0 to 100).
-* `client.historic_data` – Ordered Dictionary of hourly averages with timestamp for minimum and maximum temperature and humidity
+* `client.historic_data` – Ordered Dictionary of hourly minimum and maximum including timestamp for temperature and humidity
 
 ## Available setters
 


### PR DESCRIPTION
Thanks alot to @gdyuldin and his support for historic data in #13 which is the base for this pull request.

With the help of my freezer compartment and the sun I figured out that the `historic_data` indeed captures `min` and `max` values for `temperature` and `humidity` per hour instead of the average I suspected first in #7 . Unfortunately the decoding wasn't correct so I fixed it here.

I noticed the support for negative temperatures introduced in [commit](https://github.com/h4/lywsd02/commit/89fb06d235695d4e83bc2a4996c47eb97664fb89) was overwritten so I restored it.

I also added a description in the README for the `historic_data` property