### PR TITLE
Fix local timezone detection when DST is in effect

### DIFF
--- a/lywsd02/client.py
+++ b/lywsd02/client.py
@@ -108,6 +108,8 @@ class Lywsd02Client:
     def time(self, dt: datetime):
         if self._tz_offset is not None:
             tz_offset = self._tz_offset
+        elif time.daylight != 0:
+            tz_offset = int(-time.altzone / 3600)
         else:
             tz_offset = int(-time.timezone / 3600)
 


### PR DESCRIPTION
This fixes detection from #10 during Daylight Saving Time.

Per Python docs:
  time.daylight
    Nonzero if a DST timezone is defined.
  time.altzone
    (...) Only use this if daylight is nonzero.