### PR TITLE
Add simple script to synchronize time and read values from sensors

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,7 +23,7 @@
 
     Note: use `python3` if your system defaults to Python 2.
 
-## Usage
+## Usage (library)
 
 Instantiate client with Lywsd02 mac address
 
@@ -58,6 +58,21 @@ with client.connect():
     print(data.humidity)
     print(client.battery)
 ```
+
+## Usage (helper script)
+
+This library also installs a simple command-line utility called `lywsd02`.
+
+It allows to synchronize time and read data from devices:
+
+```bash
+lywsd02 sync 3F:59:C8:80:70:BE
+lywsd02 read 3F:59:C8:80:70:BE 3F:59:C8:80:70:BF
+```
+
+Consult `lywsd02 -h` to get information on all possible actions.
+
+Note that you may need to replace `lywsd02` with `~/.local/bin/lywsd02` or some other path, depending on your installation settings.
 
 ## Available properties
 

--- a/scripts/lywsd02
+++ b/scripts/lywsd02
@@ -1,0 +1,29 @@
+#!python
+
+import argparse
+import lywsd02
+
+parser = argparse.ArgumentParser()
+parser.add_argument('action', help='Action to perform, either: sync - synchronize time with this machine, read - read current values from device, setc/setf - set temperature unit on display to Celsius/Fahrenheit', choices=['sync', 'read', 'setc', 'setf'])
+parser.add_argument('mac', help='MAC address of LYWSD02 device', nargs='+')
+args = parser.parse_args()
+
+for mac in args.mac:
+	try:
+		client = lywsd02.Lywsd02Client(mac)
+		if args.action == 'sync':
+			print('Synchronizing time of {}'.format(mac))
+			client.time = datetime.datetime.now()
+		elif args.action == 'read':
+			print('Fetching data from {}'.format(mac))
+			data = client.data
+			print('Temperature: {}°C'.format(data.temperature))
+			print('Humidity: {}%'.format(data.humidity))
+			print('Battery: {}%'.format(client.battery))
+			print()
+		elif args.action == 'setc':
+			client.units = 'C'
+		elif args.action == 'setf':
+			client.units = 'F'
+	except Exception as e:
+		print(e)

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         'Programming Language :: Python :: 3.7',
     ],
     install_requires=['bluepy==1.3.0'],
+    scripts=['scripts/lywsd02'],
     author_email='mikhail.baranov@gmail.com',
     description='Lywsd02 BLE sendor Library',
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
This PR adds small script that allows to do two things:
- synchronize time on many devices,
- read current values from sensors and display it.