### PR TITLE
Fixed non-functional daylight saving time (DST) detection

### DIFF
--- a/lywsd02/client.py
+++ b/lywsd02/client.py
@@ -116,7 +116,7 @@ class Lywsd02Client:
     def tz_offset(self):
         if self._tz_offset is not None:
             return self._tz_offset
-        elif time.daylight:
+        elif time.localtime().tm_isdst > 0:
             return -time.altzone // 3600
         else:
             return -time.timezone // 3600


### PR DESCRIPTION
Original implementation is using `time.daylight` to detect if DST is active and that's not correct since the `time.daylight` returns:
> Nonzero if a DST timezone is defined.

The `time.daylight` tells us if current timezone uses DST, thus **not if the DST is currently active**. This leads to condition where `time.daylight` is always 1 and never changes since my timezone always uses DST but of course the DST is active only sometimes.

That's why we need to detect if the DST is currently active instead.

The `time.localtime().tm_isdst` returns:
> In calls to mktime(), tm_isdst may be set to 1 when daylight savings time is in effect, and 0 when it is not. A value of -1 indicates that this is not known, and will usually result in the correct state being filled in.

This should fix the DST detection.